### PR TITLE
Add material colour information to output

### DIFF
--- a/src/main/java/com/example/examplemod/ExampleMod.java
+++ b/src/main/java/com/example/examplemod/ExampleMod.java
@@ -50,6 +50,8 @@ public class ExampleMod
             Collection<IMaterialStats> stats = mat.getAllStats();
             // logger.info("mat: {}", mat.identifier);
             output += "\"" + mat.identifier + "\": {";
+            
+            output += '"colour":' + mat.materialTextColor + ',';
 
             for(IMaterialStats stat : stats) {
                 String statIdentifier = stat.getIdentifier();


### PR DESCRIPTION
Extends the material base output to include colour information. This is used within tinkers to colour the part textures.